### PR TITLE
Correct entry for SPIKE to unpackaged

### DIFF
--- a/kali-tools.nix
+++ b/kali-tools.nix
@@ -372,7 +372,7 @@ in {
   snmpcheck = pkgs.net-snmp;
   spectools = cantfind;
   spiderfoot = cantfind;
-  spike = pkgs.spike;
+  spike = cantfind;
   spooftooph = pkgs.spooftooph;
   sqldict = cantfind;
   sqlitebrowser = pkgs.sqlitebrowser;


### PR DESCRIPTION
SPIKE is not present in Nixpkgs as of 24.11 nor in any NUR repo as of https://github.com/nix-community/nur-combined/commit/993c152f05fa821d3d6fcc1ee261b9c8f1fb58eb.

If some future human wants to package it, there's [Kali's fork](https://gitlab.com/kalilinux/packages/spike/-/commits/kali/master), not sure about any others.

(Moved from https://github.com/JJJollyjim/arewehackersyet/pull/13.)